### PR TITLE
Fix process.platform check for Windows

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -8,7 +8,7 @@ var path = require('path');
 var semver = require('semver');
 
 var platform = process.platform === 'darwin' ? 'osx' : 
-  process.platform === 'win3' ? 'win' : process.platform;
+  process.platform === 'win32' ? 'win' : process.platform;
 
 var ext = platform === 'linux' ? '.tar.gz' : '.zip';
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var progress = require('progress-stream');
 var semver = require('semver');
 
 var platform = process.platform === 'darwin' ? 'osx' : 
-  process.platform === 'win3' ? 'win' : process.platform;
+  process.platform === 'win32' ? 'win' : process.platform;
 
 var ext = platform === 'linux' ? '.tar.gz' : '.zip';
 


### PR DESCRIPTION
Currently this package doesn't work on Windows at all. On my machine it attempts to download http://dl.nwjs.io/v0.12.1/nwjs-v0.12.1-win32-x64.zip, which doesn't exist (should be http://dl.nwjs.io/v0.12.1/nwjs-v0.12.1-win-x64.zip)

This fixes that. Looks like it's just a typo, as 'win3' is not a value that process.platform will ever currently return: https://nodejs.org/api/process.html#process_process_platform
